### PR TITLE
Refactor: Replace <img> tags with Next.js <Image> components

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Other configurations may be here
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'upload.wikimedia.org',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
+};
+
+module.exports = nextConfig;

--- a/src/components/layouts/Footer1.js
+++ b/src/components/layouts/Footer1.js
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image";
 
 export default function Footer1() {
   return (
@@ -10,7 +11,7 @@ export default function Footer1() {
           <div className="row justify-content-lg-between">
             <div className="col-xl-3 col-sm-6">
               <div className="footer_widget footer_about mb50-lg">
-                <div className="site_logo"><Link href="/"><img className="logo_before" src="/images/logo/logo.svg"  alt="Petopia Logo"/></Link></div>
+                <div className="site_logo"><Link href="/"><Image className="logo_before" src="/images/logo/logo.svg" alt="Petopia Logo" width={500} height={500} unoptimized /></Link></div>
                 <p>Tristique nulla aliquet enim tortor at auctor urna nunc. Massa enim nec dui nunc mattis enim ut tellus. Sed ut perspiciatis unde ...</p>
                 <div className="footer_hotline iconbox_item iconbox_lefticon">
                   <div className="item_icon"><i className="fas fa-phone-alt"></i></div>

--- a/src/components/layouts/Header3 copy.js
+++ b/src/components/layouts/Header3 copy.js
@@ -5,6 +5,7 @@ import { useState, useEffect } from "react";
 import Menu from "./Menu";
 import MobileMenu from "./MobileMenu";
 import DynamicLogo from "./DynamicLogo";
+import Image from "next/image";
 
 export default function Header1({
   scroll,
@@ -178,9 +179,11 @@ export default function Header1({
                       <ul className="cart_items_list unorder_list_block">
                         <li>
                           <Link className="item_image" href="shop-details">
-                            <img
+                            <Image
                               src="/images/cart/cart_img_1.jpg"
                               alt="Pet Care Service"
+                              width={500}
+                              height={500}
                             />
                           </Link>
                           <div className="item_content">
@@ -197,9 +200,11 @@ export default function Header1({
                         </li>
                         <li>
                           <Link className="item_image" href="shop-details">
-                            <img
+                            <Image
                               src="/images/cart/cart_img_2.jpg"
                               alt="Pet Care Service"
+                              width={500}
+                              height={500}
                             />
                           </Link>
                           <div className="item_content">

--- a/src/components/layouts/elements/BackToTop.js
+++ b/src/components/layouts/elements/BackToTop.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import Image from "next/image";
 
 export default function WhatsappButton() {
   const [visible, setVisible] = useState(false);
@@ -23,10 +24,13 @@ export default function WhatsappButton() {
           className="whatsapp-float"
           aria-label="Kapcsolat WhatsAppon"
         >
-          <img
+          <Image
             src="https://upload.wikimedia.org/wikipedia/commons/6/6b/WhatsApp.svg"
             alt="WhatsApp ikon"
             className="whatsapp-logo"
+            width={50}
+            height={50}
+            unoptimized
           />
         </a>
       )}

--- a/src/components/sections/PageTitle.js
+++ b/src/components/sections/PageTitle.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import React from "react";
+import Image from "next/image";
 
 const PageTitle = (props) => {
   return (
@@ -14,7 +15,7 @@ const PageTitle = (props) => {
           <p className="text">{props.pageText}</p>
         </div>
       </div>
-      <img className={props.customClass} src={props.floatImage} alt=""/>
+      <Image className={props.customClass} src={props.floatImage} alt="" width={500} height={500} />
     </section>
   );
 };

--- a/src/components/sections/home/Banner.js
+++ b/src/components/sections/home/Banner.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Banner = () => {
   return (
@@ -86,10 +87,10 @@ const Banner = () => {
       </svg>
     </div>
     <div className="decoration_item chat_img_1">
-      <img src="/images/banner/cat_img_1.png" alt="Cat Image"/>
+      <Image src="/images/banner/cat_img_1.png" alt="Cat Image" width={500} height={500} />
     </div>
     <div className="decoration_item chat_img_2">
-      <img src="/images/banner/cat_img_2.png" alt="Cat Image"/>
+      <Image src="/images/banner/cat_img_2.png" alt="Cat Image" width={500} height={500} />
     </div>
   </section>
 

--- a/src/components/sections/home/Banner2.js
+++ b/src/components/sections/home/Banner2.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Banner2 = () => {
   return (
@@ -10,7 +11,7 @@ const Banner2 = () => {
       <div className="row align-items-center">
         <div className="col order-last col-lg-6">
           <div className="banner_image">
-            <img src="/images/banner/dogs_img_1.png" alt="Pet Dogs Image"/>
+            <Image src="/images/banner/dogs_img_1.png" alt="Pet Dogs Image" width={500} height={500} />
           </div>
         </div>
         <div className="col col-lg-6">

--- a/src/components/sections/home/BlogPost.js
+++ b/src/components/sections/home/BlogPost.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const BlogPost = () => {
   return (
@@ -22,9 +23,11 @@ const BlogPost = () => {
                   </li>
                 </ul>
                 <Link className="item_image" href="news-details">
-                  <img
+                  <Image
                     src="/images/blog/blog_image_1.jpg"
                     alt="Pet Care Image"
+                    width={500}
+                    height={500}
                   />
                 </Link>
                 <div className="item_content">
@@ -63,9 +66,11 @@ const BlogPost = () => {
                   </li>
                 </ul>
                 <Link className="item_image" href="news-details">
-                  <img
+                  <Image
                     src="/images/blog/blog_image_2.jpg"
                     alt="Pet Care Image"
+                    width={500}
+                    height={500}
                   />
                 </Link>
                 <div className="item_content">
@@ -104,9 +109,11 @@ const BlogPost = () => {
                   </li>
                 </ul>
                 <Link className="item_image" href="news-details">
-                  <img
+                  <Image
                     src="/images/blog/blog_image_3.jpg"
                     alt="Pet Care Image"
+                    width={500}
+                    height={500}
                   />
                 </Link>
                 <div className="item_content">

--- a/src/components/sections/home/Contact.js
+++ b/src/components/sections/home/Contact.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Contact = () => {
   return (
@@ -75,10 +76,10 @@ const Contact = () => {
     </div>
 
     <div className="decoration_item shape_image_1">
-      <img src="/images/shape/shape_purr.svg" alt="Pet Purr"/>
+      <Image src="/images/shape/shape_purr.svg" alt="Pet Purr" width={500} height={500} unoptimized />
     </div>
     <div className="decoration_item shape_image_2">
-      <img src="/images/shape/shape_cat.svg" alt="Cat"/>
+      <Image src="/images/shape/shape_cat.svg" alt="Cat" width={500} height={500} unoptimized />
     </div>
   </section>
 

--- a/src/components/sections/home/Faq.js
+++ b/src/components/sections/home/Faq.js
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useState } from 'react';
+import Image from "next/image";
 
 const Faq = () => {
   const [isActive, setIsActive] = useState({
@@ -87,16 +88,16 @@ const Faq = () => {
         <div className="col col-lg-6">
           <div className="about_image_1">
             <div className="image_1 p-0">
-              <img src="/images/about/about_img_1.jpg" alt="Pet Doctor"/>
+              <Image src="/images/about/about_img_1.jpg" alt="Pet Doctor" width={500} height={500} />
             </div>
             <div className="image_2">
-              <img src="/images/about/about_img_2.jpg" alt="Cat Image"/>
+              <Image src="/images/about/about_img_2.jpg" alt="Cat Image" width={500} height={500} />
             </div>
             <div className="image_3">
-              <img src="/images/about/about_img_3.jpg" alt="Dog Image"/>
+              <Image src="/images/about/about_img_3.jpg" alt="Dog Image" width={500} height={500} />
             </div>
             <div className="shape_img_1">
-              <img src="/images/shape/shape_circle_1.svg" alt="Yellow Circle"/>
+              <Image src="/images/shape/shape_circle_1.svg" alt="Yellow Circle" width={500} height={500} unoptimized />
             </div>
           </div>
         </div>
@@ -104,7 +105,7 @@ const Faq = () => {
     </div>
 
     <div className="decoration_item shape_dot_1">
-      <img src="/images/shape/shape_dot_group_1.svg" alt="Colorful Dots"/>
+      <Image src="/images/shape/shape_dot_group_1.svg" alt="Colorful Dots" width={500} height={500} unoptimized />
     </div>
   </section>
 

--- a/src/components/sections/home/Features.js
+++ b/src/components/sections/home/Features.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Features = () => {
   return (
@@ -10,10 +11,10 @@ const Features = () => {
         <div className="col col-lg-5">
           <div className="feature_image">
             <div className="image_wrap">
-              <img src="/images/feature/feature_img_1.jpg" alt="Pet Grooming Service Image"/>
+              <Image src="/images/feature/feature_img_1.jpg" alt="Pet Grooming Service Image" width={500} height={500} />
             </div>
             <div className="shape_image_1">
-              <img src="/images/shape/shape_butterfly.svg" alt="Butterfly Shape"/>
+              <Image src="/images/shape/shape_butterfly.svg" alt="Butterfly Shape" width={500} height={500} unoptimized />
             </div>
           </div>
         </div>
@@ -44,13 +45,13 @@ const Features = () => {
       </div>
     </div>
     <div className="decoration_item shape_image_2">
-      <img src="/images/shape/shape_group_1.svg" alt="Pet Tools Box"/>
+      <Image src="/images/shape/shape_group_1.svg" alt="Pet Tools Box" width={500} height={500} unoptimized />
     </div>
     <div className="decoration_item decoration_image_1">
-      <img src="/images/feature/feature_img_2.jpg" alt="Pet Grooming Service Image"/>
+      <Image src="/images/feature/feature_img_2.jpg" alt="Pet Grooming Service Image" width={500} height={500} />
     </div>
     <div className="decoration_item decoration_image_2">
-      <img src="/images/feature/feature_img_3.jpg" alt="Pet Grooming Service Image"/>
+      <Image src="/images/feature/feature_img_3.jpg" alt="Pet Grooming Service Image" width={500} height={500} />
     </div>
   </section>
 

--- a/src/components/sections/home/Gallery.js
+++ b/src/components/sections/home/Gallery.js
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image";
 
 const Gallery = () => {
   return (
@@ -14,7 +15,7 @@ const Gallery = () => {
       <div className="row">
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_1.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_1.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -24,7 +25,7 @@ const Gallery = () => {
 
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_2.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_2.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -34,7 +35,7 @@ const Gallery = () => {
 
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_3.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_3.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -44,7 +45,7 @@ const Gallery = () => {
 
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_4.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_4.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -54,7 +55,7 @@ const Gallery = () => {
 
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_5.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_5.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -64,7 +65,7 @@ const Gallery = () => {
 
         <div className="col col-lg-4 col-md-6 col-sm-6">
           <div className="gallery_item">
-            <div className="item_image"><img src="/images/gallery/gallery_img_6.jpg" alt="Pet Image"/></div>
+            <div className="item_image"><Image src="/images/gallery/gallery_img_6.jpg" alt="Pet Image" width={500} height={500} /></div>
             <Link className="item_content" href="#!">
               <span className="d-block"><small>SERVICES</small></span>
               <strong className="d-block">Cat Grooming</strong>
@@ -74,7 +75,7 @@ const Gallery = () => {
       </div>
     </div>
     <div className="decoration_item shape_dot_1">
-      <img src="/images/shape/shape_dot_group_2.svg" alt="Colorful Dots"/>
+      <Image src="/images/shape/shape_dot_group_2.svg" alt="Colorful Dots" width={500} height={500} unoptimized />
     </div>
   </section>
 

--- a/src/components/sections/home/Pricing.js
+++ b/src/components/sections/home/Pricing.js
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import React, { useState } from 'react';
+import Image from "next/image";
 
 const Pricing = () => {
   const [activeIndex, setActiveIndex] = useState(1);
@@ -251,10 +252,10 @@ const Pricing = () => {
       </div>
     </div>
     <div className="decoration_item shape_dot_1">
-      <img src="/images/shape/shape_dot_group_3.svg" alt="Colorful Dots"/>
+      <Image src="/images/shape/shape_dot_group_3.svg" alt="Colorful Dots" width={500} height={500} unoptimized />
     </div>
     <div className="decoration_item shape_dot_2">
-      <img src="/images/shape/shape_dot_group_4.svg" alt="Colorful Dots"/>
+      <Image src="/images/shape/shape_dot_group_4.svg" alt="Colorful Dots" width={500} height={500} unoptimized />
     </div>
   </section>
 

--- a/src/components/sections/home/Service.js
+++ b/src/components/sections/home/Service.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Service = () => {
   return (
@@ -41,7 +42,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>
@@ -74,7 +75,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>
@@ -107,7 +108,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>
@@ -137,7 +138,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>
@@ -170,7 +171,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>
@@ -203,7 +204,7 @@ const Service = () => {
                   <i className="far fa-long-arrow-right"></i>
                 </Link>
                 <div className="decoration_image">
-                  <img src="/images/shape/shape_paws.svg" alt="Pet Paws" />
+                  <Image src="/images/shape/shape_paws.svg" alt="Pet Paws" width={500} height={500} unoptimized />
                 </div>
               </div>
             </div>

--- a/src/components/sections/home/Subscription.js
+++ b/src/components/sections/home/Subscription.js
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 
 const Subscription = () => {
   return (
@@ -35,7 +36,7 @@ const Subscription = () => {
               }}
             ></div>
             <div className="decoration_item shape_image_1">
-              <img src="/images/shape/shape_path_5.svg" alt="Shape Image" />
+              <Image src="/images/shape/shape_path_5.svg" alt="Shape Image" width={500} height={500} unoptimized />
             </div>
             {/* <div className="decoration_item shape_image_2">
               <img src="/images/shape/shape_circle_1.svg" alt="Shape Image" />
@@ -44,7 +45,7 @@ const Subscription = () => {
               <img src="/images/about/about_img_4.png" alt="Pet Image" />
             </div> */}
             <div className="decoration_item pet_image_2">
-              <img src="/images/about/about_img_5.png" alt="Pet Image" />
+              <Image src="/images/about/about_img_5.png" alt="Pet Image" width={500} height={500} />
             </div>
           </div>
         </div>

--- a/src/components/sections/home/Team.js
+++ b/src/components/sections/home/Team.js
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image";
 
 const Team = () => {
   return (
@@ -14,7 +15,7 @@ const Team = () => {
         <div className="col col-lg-3 col-md-6 col-sm-6">
           <div className="team_item text-center">
             <div className="item_image">
-            <img src="/images/team/team_img_1.png" alt="Team Image"/>
+            <Image src="/images/team/team_img_1.png" alt="Team Image" width={500} height={500} />
             </div>
             <div className="item_content">
               <h3 className="item_title">Cameron Rogers</h3>
@@ -31,7 +32,7 @@ const Team = () => {
         <div className="col col-lg-3 col-md-6 col-sm-6">
           <div className="team_item text-center">
             <div className="item_image">
-            <img src="/images/team/team_img_2.png" alt="Team Image"/>
+            <Image src="/images/team/team_img_2.png" alt="Team Image" width={500} height={500} />
             </div>
             <div className="item_content">
               <h3 className="item_title">Irene Sotelo</h3>
@@ -48,7 +49,7 @@ const Team = () => {
         <div className="col col-lg-3 col-md-6 col-sm-6">
           <div className="team_item text-center">
             <div className="item_image">
-            <img src="/images/team/team_img_3.png" alt="Team Image"/>
+            <Image src="/images/team/team_img_3.png" alt="Team Image" width={500} height={500} />
             </div>
             <div className="item_content">
               <h3 className="item_title">Cameron Rogers</h3>
@@ -65,7 +66,7 @@ const Team = () => {
         <div className="col col-lg-3 col-md-6 col-sm-6">
           <div className="team_item text-center">
             <div className="item_image">
-            <img src="/images/team/team_img_4.png" alt="Team Image"/>
+            <Image src="/images/team/team_img_4.png" alt="Team Image" width={500} height={500} />
             </div>
             <div className="item_content">
               <h3 className="item_title">Tiontay Carroll</h3>

--- a/src/components/sections/home/Testimonial.js
+++ b/src/components/sections/home/Testimonial.js
@@ -1,6 +1,7 @@
 "use client";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Autoplay, Navigation, Pagination } from "swiper/modules";
+import Image from "next/image";
 
 const swiperOptions = {
   modules: [Autoplay, Pagination, Navigation],
@@ -61,7 +62,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_1.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_1.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Home Visits</h4>
                 <span className="admin_designation">Lucas Simões</span>
@@ -82,7 +83,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_2.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_2.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Dog Boarding</h4>
                 <span className="admin_designation">Wilhelm Dowall</span>
@@ -103,7 +104,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_3.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_3.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Pet Training</h4>
                 <span className="admin_designation">Lara Madrigal</span>
@@ -124,7 +125,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_4.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_4.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Home Visit</h4>
                 <span className="admin_designation">Lara Madrigal</span>
@@ -145,7 +146,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_1.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_1.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Home Visits</h4>
                 <span className="admin_designation">Lucas Simões</span>
@@ -166,7 +167,7 @@ const Testimonial = () => {
         <SwiperSlide className="carousel_item">
           <div className="testimonial_item">
             <div className="testimonial_admin">
-              <div className="admin_thumbnail"><img src="/images/meta/thumbnail_img_2.png" alt="Pet Thumbnail Image"/></div>
+              <div className="admin_thumbnail"><Image src="/images/meta/thumbnail_img_2.png" alt="Pet Thumbnail Image" width={500} height={500} /></div>
               <div className="admin_info">
                 <h4 className="admin_name">Dog Boarding</h4>
                 <span className="admin_designation">Wilhelm Dowall</span>


### PR DESCRIPTION
I've converted all standard HTML <img> tags to Next.js <Image> components across the src directory to leverage Next.js image optimization capabilities.

- I added `import Image from 'next/image'` where necessary.
- I extracted `src`, `alt`, `width`, `height`, and `className` attributes.
- I applied the `unoptimized` prop for SVG images.
- I used default dimensions (500x500) for images where original dimensions were not specified. These instances have been logged, and I've informed you about them for review.
- I updated `next.config.js` to include `remotePatterns` for `upload.wikimedia.org` to allow optimization of images from this domain.